### PR TITLE
Rename codeship service to avoid warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Use [codeship-services.yml](codeship-services.yml) file to
 build `cypress/cypress_codeship_test` image (from the above Dockerfile).
 
 ```yaml
-cypress_codeship_test:
+cypress-codeship-test:
   build:
     image: cypress/cypress_codeship_test
     dockerfile: Dockerfile
@@ -42,7 +42,7 @@ and run one or more E2E tests in parallel or in sequence.
 
 ```yaml
 - name: "Cypress E2E tests"
-  service: cypress_codeship_test
+  service: cypress-codeship-test
   command: npm run cy:run
 ```
 

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,4 +1,4 @@
-cypress_codeship_test:
+cypress-codeship-test:
   build:
     image: cypress/cypress_codeship_test
     dockerfile: Dockerfile

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,21 +1,21 @@
 - type: parallel
   steps:
     - name: "print env vars"
-      service: cypress_codeship_test
+      service: cypress-codeship-test
       command: node_modules/.bin/print-env CI
 
     - name: "Ls -la"
-      service: cypress_codeship_test
+      service: cypress-codeship-test
       command: ls -la node_modules/.bin
 
     - name: "Verify Cypress"
-      service: cypress_codeship_test
+      service: cypress-codeship-test
       command: npm run cy:verify
 
     - name: "Run Cypress 1"
-      service: cypress_codeship_test
+      service: cypress-codeship-test
       command: npm run env:run
 
     - name: "Run Cypress 2"
-      service: cypress_codeship_test
+      service: cypress-codeship-test
       command: npm run env:run


### PR DESCRIPTION
Docker Pro throws the following warning with the current service name:

```
****** CODESHIP WARNING ******
Underscores in service names may cause issues with Docker networks. Please rename service "cypress_codeship_test" to not include "_".
****** CODESHIP WARNING ******
```

This PR renames the service to use `-` instead of `_` to avoid the warning.